### PR TITLE
Clean up unrooted boot patching cp errors in log

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
@@ -456,10 +456,7 @@ abstract class MagiskInstallImpl protected constructor(
             return false
         }
 
-        // Fix up binaries
         srcBoot.delete()
-        "cp_readlink $installDir".sh()
-
         return true
     }
 


### PR DESCRIPTION
cp: can't preserve ownership of 'busybox': Operation not permitted
cp: can't preserve ownership of 'magisk32': Operation not permitted
cp: can't preserve ownership of 'magisk64': Operation not permitted
cp: can't preserve ownership of 'magiskboot': Operation not permitted
cp: can't preserve ownership of 'magiskinit': Operation not permitted
cp: can't preserve ownership of 'magiskpolicy': Operation not permitted

remove call since cp_readlink shouldn't be necessary with installDir getting cleaned up regularly